### PR TITLE
Improve simulation UI.

### DIFF
--- a/app/public/lib/draw2d_extensions/draw2d_digital_connections.js
+++ b/app/public/lib/draw2d_extensions/draw2d_digital_connections.js
@@ -137,8 +137,6 @@ function createDigitalConnection(sourcePort, targetPort) {
     );
     c.setSource(sourcePort);
     c.setTarget(targetPort);
-    // TODO: add check to make sure this connection does not exist
-    // already?
     return c;
 }
 

--- a/app/public/lib/draw2d_extensions/draw2d_digital_connections.js
+++ b/app/public/lib/draw2d_extensions/draw2d_digital_connections.js
@@ -26,6 +26,13 @@ draw2d.layout.locator.BusLabelLocator = draw2d.layout.locator.ConnectionLocator.
     }
 });
 
+// The dispatch lock ensures that a connection does not trigger the
+// InferWidth message multiple times in a short period of time.
+// It would since the "connect" event is fired multiple times when a 
+// connection is created (connect source and target).
+// This is just for performance.
+dispatchLock = "undefined";
+
 draw2d.Connection = draw2d.Connection.extend({
 
     NAME: "Connection",
@@ -49,25 +56,18 @@ draw2d.Connection = draw2d.Connection.extend({
         });
     },
 
-    // The dispatch lock ensures that a connection does not trigger the
-    // InferWidth message multiple times in a short period of time.
-    // It would since the "connect" event is fired multiple times when a 
-    // connection is created (connect source and target).
-    // This is just for performance.
-    dispatchLock: "undefined", 
-
     sendInferWidthsMessage: function() {
         if (dispatchInferWidthsMessage !== "undefined" &&
-            this.dispatchLock === "undefined") {
+            dispatchLock === "undefined") {
             // Dispatch the message after 20ms, to give the time to the
             // function to finish. This way the inference function will
             // access the version of the state that also contains the
             // connection.
-            this.dispatchLock = setTimeout(() => {
+            dispatchLock = setTimeout(() => {
                 dispatchInferWidthsMessage();
-                this.dispatchLock = "undefined"; // Clear timer.
+                this.dispatchLock = "undefined"; // Release Lock.
             }, 20);
-        } else if (this.dispatchTimer === "undefined") {
+        } else if (dispatchLock === "undefined") {
             console.log("Warning: connection trying to dispatch a JS InferWidths message but dispatcher is not defined.")
         }
     },

--- a/src/Common/Helpers.fs
+++ b/src/Common/Helpers.fs
@@ -38,3 +38,12 @@ let listSet (lst : 'a list) (item : 'a) (idx : int) : 'a list =
     // Remove the first element of p2.
     let _, p2 = List.splitAt 1 p2
     p1 @ [item] @ p2
+
+/// Crop a string to the specified length.
+/// fromStart indicates whether you want the first <len> characters or the last
+/// <len> characters.
+let cropToLength (len : int) (fromStart : bool) (str : string) =
+    match str.Length <= len with
+    | true -> str
+    | false when fromStart -> str.[..len-1] + "..." // From start.
+    | false -> "..." + str.[str.Length - len..]     // From end.

--- a/src/Renderer/Draw2dWrapper/Draw2dWrapper.fs
+++ b/src/Renderer/Draw2dWrapper/Draw2dWrapper.fs
@@ -188,7 +188,7 @@ let private editComponentLabel (canvas : JSCanvas) (id : string) (newLabel : str
     let jsComponent = draw2dLib.getComponentById canvas id
     if isNull jsComponent
     then failwithf "what? could not find diagram component with Id: %s" id
-    else jsComponent?children?data?(0)?figure?setText(newLabel) // TODO: this only works for labels and it is very hacky.
+    else jsComponent?children?data?(0)?figure?setText(newLabel)
 
 // React wrapper.
 

--- a/src/Renderer/Draw2dWrapper/Draw2dWrapper.fs
+++ b/src/Renderer/Draw2dWrapper/Draw2dWrapper.fs
@@ -192,6 +192,8 @@ let private editComponentLabel (canvas : JSCanvas) (id : string) (newLabel : str
 
 // React wrapper.
 
+type DisplayModeType = Hidden | VisibleSmall | VisibleLarge
+
 type private Draw2dReactProps = {
     Dispatch : JSDiagramMsg -> unit
     DisplayMode : DisplayModeType
@@ -208,8 +210,9 @@ type private Draw2dReact(initialProps) =
 
     override this.render() =
         let style = match this.props.DisplayMode with
-                    | DisplayModeType.Hidden -> canvasHiddenStyle
-                    | DisplayModeType.Visible -> canvasVisibleStyle
+                    | Hidden -> canvasHiddenStyle
+                    | VisibleSmall -> canvasVisibleStyleS
+                    | VisibleLarge -> canvasVisibleStyleL
         div [ Id divId; style ] []
 
 let inline private createDraw2dReact props = ofType<Draw2dReact,_,_> props []

--- a/src/Renderer/FilesIO.fs
+++ b/src/Renderer/FilesIO.fs
@@ -60,7 +60,7 @@ let private getBaseNameNoExtension filePath =
 let private projectFilters =
     ResizeArray [
         createObj [
-            "name" ==> "Diagrams project" // TODO rename this.
+            "name" ==> "Diagrams project"
             "extensions" ==> ResizeArray [ "dprj" ]
         ]
     ] |> Some

--- a/src/Renderer/UI/FileMenuView.fs
+++ b/src/Renderer/UI/FileMenuView.fs
@@ -342,8 +342,8 @@ let viewTopMenu model dispatch =
                 Navbar.Item.div [] [
                     Navbar.Item.div [] [
                         Breadcrumb.breadcrumb [ Breadcrumb.HasArrowSeparator ] [
-                            Breadcrumb.item [] [ str projectPath ]
-                            Breadcrumb.item [] [ str fileName ]
+                            Breadcrumb.item [] [ str <| cropToLength 30 false projectPath ]
+                            Breadcrumb.item [] [ span [Style [FontWeight "bold"]] [str fileName] ]
                         ]
                     ]
                 ]

--- a/src/Renderer/UI/FileMenuView.fs
+++ b/src/Renderer/UI/FileMenuView.fs
@@ -30,8 +30,6 @@ let private loadStateIntoCanvas state model dispatch =
     // Finally load the new state in the canvas.
     let components, connections = state
     List.map model.Diagram.LoadComponent components |> ignore
-    // TODO: disallow inference from running when loading these connections and
-    // run it only once at the end instead?
     List.map (model.Diagram.LoadConnection true) connections |> ignore
     model.Diagram.FlushCommandStack () // Discard all undo/redo.
     // Run the a connection widhts inference.

--- a/src/Renderer/UI/MainView.fs
+++ b/src/Renderer/UI/MainView.fs
@@ -141,9 +141,13 @@ let hideView model dispatch =
     ]
 
 let displayView model dispatch =
+    // Simulation has larger right column.
+    let canvasStyle, rightSectionStyle =
+        if model.RightTab = Simulation then VisibleSmall, rightSectionStyleL
+                                       else VisibleLarge, rightSectionStyleS 
     div [] [
         viewTopMenu model dispatch
-        model.Diagram.CanvasReactElement (JSDiagramMsg >> dispatch) Visible
+        model.Diagram.CanvasReactElement (JSDiagramMsg >> dispatch) canvasStyle
         viewNoProjectMenu model dispatch
         viewPopup model
         viewNotifications model dispatch

--- a/src/Renderer/UI/MessageType.fs
+++ b/src/Renderer/UI/MessageType.fs
@@ -5,8 +5,6 @@ open JSTypes
 open SimulatorTypes
 open Fable.Import.React
 
-type DisplayModeType = Hidden | Visible
-
 type RightTab =
     | Properties
     | Catalogue

--- a/src/Renderer/UI/MessageType.fs
+++ b/src/Renderer/UI/MessageType.fs
@@ -48,6 +48,7 @@ type Msg =
     | StartSimulation of Result<SimulationData, SimulationError>
     | SetSimulationGraph of SimulationGraph
     | SetSimulationBase of NumberBase
+    | IncrementSimulationClockTick
     | EndSimulation
     | ChangeRightTab of RightTab
     | SetHighlighted of ComponentId list * ConnectionId list

--- a/src/Renderer/UI/SimulationView.fs
+++ b/src/Renderer/UI/SimulationView.fs
@@ -188,8 +188,9 @@ let private viewSimulationData (simData : SimulationData) model dispatch =
                 Button.Color IsSuccess
                 Button.OnClick (fun _ ->
                     feedClockTick simData.Graph |> SetSimulationGraph |> dispatch
+                    IncrementSimulationClockTick |> dispatch
                 )
-            ] [ str "Clock Tick" ]
+            ] [ str <| sprintf "Clock Tick %d" simData.ClockTickNumber ]
     let maybeStatefulComponents =
         let stateful = extractStatefulComponents simData.Graph
         match List.isEmpty stateful with

--- a/src/Renderer/UI/SimulationView.fs
+++ b/src/Renderer/UI/SimulationView.fs
@@ -37,15 +37,9 @@ let private splittedLine leftContent rightConent =
         ]
     ]
 
-/// Crop a string to the specified length.
-let private cropToLength (len : int) (str : string) : string =
-    match str.Length <= len with
-    | true -> str
-    | false -> str.[..len] + "..."
-
 /// Pretty print a label with its width.
 let private makeIOLabel label width =
-    let label = cropToLength 15 label
+    let label = cropToLength 15 true label
     match width with
     | 1 -> label
     | w -> sprintf "%s (%d bits)" label w

--- a/src/Renderer/UI/SimulationView.fs
+++ b/src/Renderer/UI/SimulationView.fs
@@ -37,8 +37,15 @@ let private splittedLine leftContent rightConent =
         ]
     ]
 
+/// Crop a string to the specified length.
+let private cropToLength (len : int) (str : string) : string =
+    match str.Length <= len with
+    | true -> str
+    | false -> str.[..len] + "..."
+
 /// Pretty print a label with its width.
 let private makeIOLabel label width =
+    let label = cropToLength 15 label
     match width with
     | 1 -> label
     | w -> sprintf "%s (%d bits)" label w

--- a/src/Renderer/UI/Style.fs
+++ b/src/Renderer/UI/Style.fs
@@ -2,38 +2,49 @@ module DiagramStyle
 
 open Fable.Helpers.React.Props
 
-let headerHeight = "52px"
-let rightSectionWidth = "400px"
+let private headerHeight = "52px"
+let private rightSectionWidthS = "400px" // Small right section.
+let private rightSectionWidthL = "650px" // Large right section.
 
 let navbarStyle = Style [
     Width "100%"
     Height headerHeight
 ]
 
-let rightSectionStyle = Style [
+let private rightSectionStyle width = Style [
     Position "fixed"
     Right "0px"
     Height (sprintf "calc(100%s - %s)" "%" headerHeight) // WindowSize - headerHeight
-    Width rightSectionWidth
+    Width width
     OverflowX "hidden"
     OverflowY "scroll"
     BorderTop "2px solid lightgray"
 ]
 
+/// Style when right column is expanded.
+let rightSectionStyleS = rightSectionStyle rightSectionWidthS
+/// Style when right column is small.
+let rightSectionStyleL = rightSectionStyle rightSectionWidthL
+
 let canvasHiddenStyle = Style [
     Display "none"
 ]
 
-let canvasVisibleStyle = Style [
+let private canvasVisibleStyle right = Style [
     Display "block"
     Position "absolute" // Required to work.
     Overflow "scroll"
     Top headerHeight // Placed just under the header.
     Left "0px"
     Bottom "0px"
-    Right rightSectionWidth
+    Right right
     BorderTop "2px solid lightgray"
 ]
+
+/// Style when right column is expanded.
+let canvasVisibleStyleS = canvasVisibleStyle rightSectionWidthL
+/// Style when right column is small.
+let canvasVisibleStyleL = canvasVisibleStyle rightSectionWidthS
 
 let canvasSmallMenuStyle = Style [
     Display "block"
@@ -62,7 +73,7 @@ let notificationStyle = Style [
 ]
 
 let simulationNumberStyle = Style [
-    Width "100px"
+    Width "320px"
     Height "30px"
 ]
 

--- a/src/Simulator/CanvasStateAnalyser.fs
+++ b/src/Simulator/CanvasStateAnalyser.fs
@@ -1,5 +1,5 @@
 (*
-    Analyser.fs
+    CanvasStateAnalyser.fs
 
     This module collects a series of functions that perform checks on
     CanvasState and SimulationGraph.

--- a/src/Simulator/SimulationGraphAnalyser.fs
+++ b/src/Simulator/SimulationGraphAnalyser.fs
@@ -77,9 +77,6 @@ let rec private dfs
         // A node in the stack must always be visited.
         failwithf "what? Node never visited but in the stack, while detecting cycle: %A" currNodeId
 
-// TODO with clocked components (which can have cycles) you can extend this
-// algorithm by just ignoring a node if it is clocked.
-
 /// Calculate which connections are involved in a cycle.
 let private calculateConnectionsAffected
         (connections : Connection list) 

--- a/src/Simulator/SimulationGraphAnalyser.fs
+++ b/src/Simulator/SimulationGraphAnalyser.fs
@@ -1,11 +1,16 @@
+(*
+    SimulationGraphAnalyser.fs
+
+    This module collects functions to analyse a fully merged simulation graph.
+    Analyses performed:
+    - Combinatorial logic can have no loops.
+*)
+
 module SimulationGraphAnalyser
 
 open CommonTypes
 open SimulatorTypes
 open SynchronousUtils
-
-// Checks performed:
-// - Combinatorial logic can have no loops.
 
 type private DfsType =
     // No cycle detected in the subtree. Return the new visited set and keep

--- a/src/Simulator/Simulator.fs
+++ b/src/Simulator/Simulator.fs
@@ -47,6 +47,7 @@ let prepareSimulation
                 Outputs = outputs
                 IsSynchronous = hasSynchronousComponents graph
                 NumberBase = Hex
+                ClockTickNumber = 0
             }
 
 /// Expose the feedSimulationInput function from SimulationRunner.

--- a/src/Simulator/Types.fs
+++ b/src/Simulator/Types.fs
@@ -96,6 +96,8 @@ type SimulationData = {
     IsSynchronous : bool
     // The base that should be used to display numbers in the simulation.
     NumberBase : NumberBase
+    // Keep track of the number of clock ticks of the simulation.
+    ClockTickNumber : int
 }
 
 type SimulationError = {

--- a/src/Simulator/Types.fs
+++ b/src/Simulator/Types.fs
@@ -1,3 +1,9 @@
+(*
+    Types.fs
+
+    This module collects a series of types used in the simulator logic.
+*)
+
 module SimulatorTypes
 
 open CommonTypes


### PR DESCRIPTION
fix #33 

- Add clock tick number to simulation.
- Enlarge simulation view so even long inputs (32 bits) are visible without overflow.
- If a label is too long just show the first N characters and then add three dots ...